### PR TITLE
feat: 实现文件时间戳保留功能 (#7) & 添加 CI/CD

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,0 +1,57 @@
+name: 构建并发布
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  DOTNET_PREVIEW_VERSION: '10.0.100-preview.4.25258.110'
+  SOLUTION_FILE: FFmpegFreeUI.sln
+  PROJECT_PATH: FFmpegFreeUI/FFmpegFreeUI.vbproj
+  BUILD_CONFIGURATION: Release
+  RUNTIME_IDENTIFIER: win-x64
+
+jobs:
+  build:
+    name: 构建并发布
+    runs-on: windows-latest
+
+    steps:
+    - name: 检出代码
+      uses: actions/checkout@v4
+
+    - name: 安装 .NET 10 SDK
+      shell: powershell
+      run: |
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-WebRequest -Uri https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1
+
+        .\dotnet-install.ps1 -Version $env:DOTNET_PREVIEW_VERSION -InstallDir "$env:ProgramFiles\dotnet" -Architecture x64
+
+        $env:PATH = "$env:ProgramFiles\dotnet;" + $env:PATH
+        dotnet --info
+
+    - name: 还原依赖项
+      run: dotnet restore ${{ env.SOLUTION_FILE }}
+
+    - name: 构建并发布
+      shell: pwsh
+      run: |
+        dotnet publish ${{ env.PROJECT_PATH }} `
+          --configuration ${{ env.BUILD_CONFIGURATION }} `
+          --runtime ${{ env.RUNTIME_IDENTIFIER }} `
+          --self-contained true `
+          -p:PublishSingleFile=true `
+          -p:PublishTrimmed=false `
+          -p:IncludeNativeLibrariesForSelfExtract=true `
+          -p:TargetFramework=net10.0-windows
+
+    - name: 上传构建产物
+      uses: actions/upload-artifact@v4
+      with:
+        name: FFmpegFreeUI
+        path: |
+          FFmpegFreeUI/bin/${{ env.BUILD_CONFIGURATION }}/net10.0-windows/${{ env.RUNTIME_IDENTIFIER }}/publish/*
+        if-no-files-found: error

--- a/FFmpegFreeUI/Form1.Designer.vb
+++ b/FFmpegFreeUI/Form1.Designer.vb
@@ -509,10 +509,22 @@ Partial Class Form1
         ImageList1.ColorDepth = ColorDepth.Depth32Bit
         ImageList1.ImageSize = New Size(1, 30)
         ImageList1.TransparentColor = Color.Transparent
+        '
+        ' UiCheckBoxKeepTimestamp
+        '
+        Me.UiCheckBoxKeepTimestamp = New Sunny.UI.UICheckBox()
+        Me.UiCheckBoxKeepTimestamp.Text = "保留源文件时间戳"
+        Me.UiCheckBoxKeepTimestamp.Checked = False
+        Me.UiCheckBoxKeepTimestamp.Location = New System.Drawing.Point(10, 7)
+        Me.UiCheckBoxKeepTimestamp.Size = New System.Drawing.Size(180, 30)
+        Me.UiCheckBoxKeepTimestamp.ForeColor = System.Drawing.Color.Silver
+        Me.UiCheckBoxKeepTimestamp.CheckBoxColor = System.Drawing.Color.CornflowerBlue
+        Me.UiCheckBoxKeepTimestamp.Font = New System.Drawing.Font("微软雅黑", 10.0!)
         ' 
         ' Panel1
         ' 
         Panel1.BackColor = Color.FromArgb(CByte(36), CByte(36), CByte(36))
+        Panel1.Controls.Add(UiCheckBoxKeepTimestamp)
         Panel1.Controls.Add(Label8)
         Panel1.Controls.Add(Label7)
         Panel1.Controls.Add(Label6)
@@ -4923,5 +4935,6 @@ Partial Class Form1
     Friend WithEvents UiTextBox13 As Sunny.UI.UITextBox
     Friend WithEvents Label101 As Label
     Friend WithEvents Label99 As Label
+    Friend WithEvents UiCheckBoxKeepTimestamp As Sunny.UI.UICheckBox
 
 End Class

--- a/FFmpegFreeUI/Form1.vb
+++ b/FFmpegFreeUI/Form1.vb
@@ -114,4 +114,8 @@ Public Class Form1
         Dim psi As New ProcessStartInfo With {.FileName = "https://space.bilibili.com/319785096", .UseShellExecute = True}
         Process.Start(psi)
     End Sub
+
+    Private Sub UiCheckBoxKeepTimestamp_CheckedChanged(sender As Object, e As EventArgs) Handles UiCheckBoxKeepTimestamp.CheckedChanged
+        编码任务.保留时间戳 = UiCheckBoxKeepTimestamp.Checked
+    End Sub
 End Class

--- a/FFmpegFreeUI/界面控制_添加文件.vb
+++ b/FFmpegFreeUI/界面控制_添加文件.vb
@@ -27,7 +27,10 @@ Public Class 界面控制_添加文件
                     m.自定义输出位置 = Form1.UiComboBox21.Text
             End Select
             Dim i2 As New ListViewItem(IO.Path.GetFileName(item.Text))
-            i2.SubItems.AddRange("未处理", "", "", "", "", "", "")
+            i2.SubItems.Add("未处理")
+            For j = 1 To 6
+                i2.SubItems.Add("")
+            Next
             Form1.ListView1.Items.Add(i2)
             m.列表视图项 = i2
             编码任务.队列.Add(m)

--- a/FFmpegFreeUI/编码任务.vb
+++ b/FFmpegFreeUI/编码任务.vb
@@ -3,6 +3,7 @@ Imports System.Text.RegularExpressions
 
 Public Class 编码任务
     Public Shared Property 队列 As New List(Of 单片任务)
+    Public Shared 保留时间戳 As Boolean = False
 
     Public Shared Sub 检查是否有可以开始的任务()
         If 获取正在处理的任务数量() < 1 Then
@@ -169,6 +170,19 @@ Public Class 编码任务
         Public Sub FFmpegProcessExited(sender As Object, e As EventArgs)
             If FFmpegProcess.ExitCode = 0 Then
                 状态 = 编码状态.已完成
+                ' 保留时间戳功能
+                If 编码任务.保留时间戳 Then
+                    Try
+                        If System.IO.File.Exists(输入文件) AndAlso System.IO.File.Exists(输出文件) Then
+                            Dim srcInfo As New System.IO.FileInfo(输入文件)
+                            System.IO.File.SetCreationTime(输出文件, srcInfo.CreationTime)
+                            System.IO.File.SetLastWriteTime(输出文件, srcInfo.LastWriteTime)
+                            System.IO.File.SetLastAccessTime(输出文件, srcInfo.LastAccessTime)
+                        End If
+                    Catch ex As Exception
+                        MsgBox($"同步时间戳失败：{ex.Message}", MsgBoxStyle.Exclamation, "时间戳同步失败")
+                    End Try
+                End If
             Else
                 状态 = 编码状态.错误
             End If


### PR DESCRIPTION
## 一 界面
![image](https://github.com/user-attachments/assets/9694fc9a-0d3d-483c-a733-a145d2b26ab3)
## 二 测试文件
本次测试选用了以下文件进行验证：
![图片 1](https://github.com/user-attachments/assets/de4d5c89-8386-4235-8fb2-d72826681afb)
![图片 2](https://github.com/user-attachments/assets/7dac21c4-75a5-4ce1-8fc7-993d3045a762)

## 三 测试过程与结果

### （一）正常输出情况
在未开启文件时间戳保留功能时，输出文件的时间戳与输出时间相同，可通过文件名进行确认。
![正常输出结果](https://github.com/user-attachments/assets/2700d915-9a48-482a-b4a0-79ab3b28d477)

### （二）开启文件时间戳保留功能后
开启文件时间戳保留功能后，输出文件的时间戳与源文件保持一致。
![开启功能后的输出结果](https://github.com/user-attachments/assets/cc478de4-3606-47ed-a870-67d7e76e2dc3)