### PR TITLE
Follow Windows app theme and add window corner setting

### DIFF
--- a/FFmpegFreeUI/功能/界面主题_v6.vb
+++ b/FFmpegFreeUI/功能/界面主题_v6.vb
@@ -1,0 +1,279 @@
+Imports System.Collections.Concurrent
+Imports System.Reflection
+Imports System.Runtime.CompilerServices
+Imports System.Text.RegularExpressions
+Imports LakeUI
+Imports Microsoft.Win32
+
+Public Module 界面主题_v6
+    Private Const Windows个性化注册表路径 As String = "Software\Microsoft\Windows\CurrentVersion\Themes\Personalize"
+    Private Const Windows应用浅色键名 As String = "AppsUseLightTheme"
+
+    Private ReadOnly 颜色属性缓存 As New ConcurrentDictionary(Of Type, PropertyInfo())
+    Private ReadOnly 控件快照表 As New ConditionalWeakTable(Of Object, 控件主题快照)
+    Private ReadOnly 已挂接控件表 As New ConditionalWeakTable(Of Control, Object)
+    Private ReadOnly 挂接标记 As New Object()
+    Private ReadOnly Html颜色表达式 As New Regex("(?i)(color\s*:\s*)(#[0-9a-f]{6}|[a-z]+)", RegexOptions.Compiled Or RegexOptions.CultureInvariant)
+
+    Private _已初始化 As Boolean
+    Private _当前浅色 As Boolean
+
+    Private NotInheritable Class 控件主题快照
+        Public ReadOnly 颜色 As New Dictionary(Of PropertyInfo, Color)
+        Public Property Html文本 As String
+        Public Property 有Html颜色 As Boolean
+    End Class
+
+    Public ReadOnly Property 当前为浅色模式 As Boolean
+        Get
+            Return _当前浅色
+        End Get
+    End Property
+
+    ''' <summary>初始化系统主题监听，并立即将当前 Windows“应用模式”应用到已加载界面。</summary>
+    Public Sub 初始化()
+        If _已初始化 Then
+            刷新主题(True)
+            Return
+        End If
+
+        _已初始化 = True
+        AddHandler SystemEvents.UserPreferenceChanged, AddressOf 系统首选项已更改
+        AddHandler Application.Idle, AddressOf 应用空闲
+        AddHandler Application.ApplicationExit, AddressOf 应用退出
+        刷新主题(True)
+    End Sub
+
+    ''' <summary>0=跟随 Windows 应用模式；1=始终使用深色。</summary>
+    Public Sub 刷新主题(Optional 强制刷新 As Boolean = False)
+        Dim 浅色 = If(设置_v6.实例对象.界面主题 = 1, False, 读取Windows应用浅色模式())
+        If Not 强制刷新 AndAlso 浅色 = _当前浅色 Then Return
+
+        _当前浅色 = 浅色
+        应用LakeUI对话框主题(浅色)
+
+        Dim forms = Application.OpenForms.Cast(Of Form).ToArray()
+        Dim mainForm = forms.OfType(Of FormMain_v6)().FirstOrDefault()
+        If mainForm IsNot Nothing Then
+            ' ThisIsYourWindow 是非可视 Component，不属于 WinForms Control 树，需要单独套用主题。
+            应用对象颜色(mainForm.ThisIsYourWindow1, 浅色)
+        End If
+        For Each form In forms
+            应用控件树(form, True)
+        Next
+    End Sub
+
+    ''' <summary>根据当前设置统一应用圆角。LakeUI 特别呈现由 ThisIsYourWindow 管理，其余窗口直接使用 DWM。</summary>
+    Public Sub 应用窗口圆角设置()
+        Dim 支持圆角 = DwmWindowStyle.IsCornerModeSupported
+        Dim mode = If(支持圆角 AndAlso 设置_v6.实例对象.窗口圆角 = 1,
+                      DwmWindowStyle.CornerMode.Round,
+                      DwmWindowStyle.CornerMode.Square)
+
+        Try
+            FormMain_v6.ThisIsYourWindow1.WindowCornerMode = mode
+        Catch
+        End Try
+
+        If 设置_v6.实例对象.窗口样式 = 2 Then Return
+        For Each form In Application.OpenForms.Cast(Of Form).ToArray()
+            If form.IsDisposed OrElse Not form.IsHandleCreated Then Continue For
+            Try
+                DwmWindowStyle.SetCornerMode(form.Handle, mode)
+            Catch
+            End Try
+        Next
+    End Sub
+
+    Public Function 读取Windows应用浅色模式() As Boolean
+        Try
+            Using key = Registry.CurrentUser.OpenSubKey(Windows个性化注册表路径, False)
+                Dim value = key?.GetValue(Windows应用浅色键名, 1)
+                Return Convert.ToInt32(value, Globalization.CultureInfo.InvariantCulture) <> 0
+            End Using
+        Catch
+            ' Windows 在未显式配置时默认使用浅色应用模式。
+            Return True
+        End Try
+    End Function
+
+    Private Sub 系统首选项已更改(sender As Object, e As UserPreferenceChangedEventArgs)
+        If Not _已初始化 OrElse 设置_v6.实例对象.界面主题 <> 0 Then Return
+        界面线程执行(
+            Sub(state)
+                If _已初始化 Then 刷新主题(False)
+            End Sub)
+    End Sub
+
+    Private Sub 应用空闲(sender As Object, e As EventArgs)
+        If Not _已初始化 Then Return
+        For Each form In Application.OpenForms.Cast(Of Form).ToArray()
+            应用控件树(form, False)
+        Next
+    End Sub
+
+    Private Sub 应用退出(sender As Object, e As EventArgs)
+        If Not _已初始化 Then Return
+        _已初始化 = False
+        RemoveHandler SystemEvents.UserPreferenceChanged, AddressOf 系统首选项已更改
+        RemoveHandler Application.Idle, AddressOf 应用空闲
+        RemoveHandler Application.ApplicationExit, AddressOf 应用退出
+    End Sub
+
+    Private Sub 应用控件树(control As Control, 强制刷新 As Boolean)
+        If control Is Nothing OrElse control.IsDisposed Then Return
+
+        Dim marker As Object = Nothing
+        Dim 首次挂接 = Not 已挂接控件表.TryGetValue(control, marker)
+        If 首次挂接 Then
+            已挂接控件表.Add(control, 挂接标记)
+            AddHandler control.ControlAdded, AddressOf 控件已添加
+        ElseIf Not 强制刷新 Then
+            ' 已挂接的树会通过 ControlAdded 捕获新增子控件；空闲扫描无需反复遍历整棵 UI 树。
+            Return
+        End If
+
+        If 首次挂接 OrElse 强制刷新 Then
+            应用对象颜色(control, _当前浅色)
+            If TypeOf control Is Form Then 应用窗体Dwm外观(DirectCast(control, Form))
+            control.Invalidate()
+        End If
+
+        For Each child As Control In control.Controls
+            应用控件树(child, 强制刷新)
+        Next
+    End Sub
+
+    Private Sub 控件已添加(sender As Object, e As ControlEventArgs)
+        If Not _已初始化 OrElse e.Control Is Nothing Then Return
+        应用控件树(e.Control, True)
+    End Sub
+
+    Private Sub 应用窗体Dwm外观(form As Form)
+        If form Is Nothing OrElse form.IsDisposed OrElse Not form.IsHandleCreated Then Return
+        Try
+            DwmWindowStyle.SetDarkMode(form.Handle, Not _当前浅色)
+        Catch
+        End Try
+
+        If 设置_v6.实例对象.窗口样式 = 2 Then Return
+        Try
+            Dim mode = If(DwmWindowStyle.IsCornerModeSupported AndAlso 设置_v6.实例对象.窗口圆角 = 1,
+                          DwmWindowStyle.CornerMode.Round,
+                          DwmWindowStyle.CornerMode.Square)
+            DwmWindowStyle.SetCornerMode(form.Handle, mode)
+        Catch
+        End Try
+    End Sub
+
+    Private Sub 应用对象颜色(target As Object, 浅色 As Boolean)
+        Dim snapshot = 获取或创建快照(target)
+        For Each pair In snapshot.颜色
+            Try
+                pair.Key.SetValue(target, If(浅色, 转换为浅色(pair.Value, pair.Key.Name), pair.Value))
+            Catch
+            End Try
+        Next
+
+        If snapshot.有Html颜色 AndAlso TypeOf target Is HtmlColorLabel Then
+            Try
+                DirectCast(target, HtmlColorLabel).Text = If(浅色, 转换Html为浅色(snapshot.Html文本), snapshot.Html文本)
+            Catch
+            End Try
+        End If
+    End Sub
+
+    Private Function 获取或创建快照(target As Object) As 控件主题快照
+        Dim existing As 控件主题快照 = Nothing
+        If 控件快照表.TryGetValue(target, existing) Then Return existing
+
+        Dim snapshot As New 控件主题快照()
+        For Each prop In 获取颜色属性(target.GetType())
+            Try
+                snapshot.颜色(prop) = DirectCast(prop.GetValue(target), Color)
+            Catch
+            End Try
+        Next
+
+        If TypeOf target Is HtmlColorLabel Then
+            Try
+                snapshot.Html文本 = DirectCast(target, HtmlColorLabel).Text
+                snapshot.有Html颜色 = Not String.IsNullOrEmpty(snapshot.Html文本) AndAlso snapshot.Html文本.IndexOf("color:", StringComparison.OrdinalIgnoreCase) >= 0
+            Catch
+            End Try
+        End If
+
+        控件快照表.Add(target, snapshot)
+        Return snapshot
+    End Function
+
+    Private Function 获取颜色属性(type As Type) As PropertyInfo()
+        Return 颜色属性缓存.GetOrAdd(
+            type,
+            Function(t)
+                Return t.GetProperties(BindingFlags.Instance Or BindingFlags.Public).
+                    Where(Function(p) p.PropertyType Is GetType(Color) AndAlso
+                                      p.CanRead AndAlso p.CanWrite AndAlso
+                                      p.SetMethod IsNot Nothing AndAlso p.SetMethod.IsPublic AndAlso
+                                      p.GetIndexParameters().Length = 0).
+                    ToArray()
+            End Function)
+    End Function
+
+    Private Function 转换为浅色(original As Color, propertyName As String) As Color
+        If original.IsEmpty OrElse original.A = 0 Then Return original
+
+        Dim maxChannel = Math.Max(original.R, Math.Max(original.G, original.B))
+        Dim minChannel = Math.Min(original.R, Math.Min(original.G, original.B))
+        If maxChannel - minChannel > 12 Then Return original
+
+        Dim gray = CInt((CInt(original.R) + CInt(original.G) + CInt(original.B)) / 3)
+        Dim mapped As Integer
+
+        If original.A < 255 Then
+            mapped = 255 - gray
+        ElseIf propertyName.IndexOf("BackColor", StringComparison.OrdinalIgnoreCase) >= 0 AndAlso gray < 112 Then
+            mapped = Math.Clamp(255 - gray \ 4, 0, 255)
+        ElseIf propertyName.IndexOf("ForeColor", StringComparison.OrdinalIgnoreCase) >= 0 AndAlso gray > 128 Then
+            mapped = 255 - gray
+        ElseIf gray <= 80 OrElse gray >= 160 Then
+            mapped = 255 - gray
+        Else
+            Return original
+        End If
+
+        Return Color.FromArgb(original.A, mapped, mapped, mapped)
+    End Function
+
+    Private Function 转换Html为浅色(text As String) As String
+        If String.IsNullOrEmpty(text) Then Return text
+        Return Html颜色表达式.Replace(
+            text,
+            Function(match)
+                Try
+                    Dim original = ColorTranslator.FromHtml(match.Groups(2).Value)
+                    Dim mapped = 转换为浅色(original, "ForeColor")
+                    If mapped.ToArgb() = original.ToArgb() Then Return match.Value
+                    Return match.Groups(1).Value & $"#{mapped.R:X2}{mapped.G:X2}{mapped.B:X2}"
+                Catch
+                    Return match.Value
+                End Try
+            End Function)
+    End Function
+
+    Private Sub 应用LakeUI对话框主题(浅色 As Boolean)
+        If 浅色 Then
+            ExMsgBoxTheme.Current = ExMsgBoxTheme.CreateLight()
+            ExInputBoxTheme.Current = ExInputBoxTheme.CreateLight()
+            ExFloatingTipTheme.Current = ExFloatingTipTheme.CreateLight()
+            ExFloatingBoxTheme.Current = ExFloatingBoxTheme.CreateLight()
+            ExOverlayMsgBoxTheme.Current = ExOverlayMsgBoxTheme.CreateLight()
+        Else
+            ExMsgBoxTheme.Current = ExMsgBoxTheme.CreateDark()
+            ExInputBoxTheme.Current = ExInputBoxTheme.CreateDark()
+            ExFloatingTipTheme.Current = ExFloatingTipTheme.CreateDark()
+            ExFloatingBoxTheme.Current = ExFloatingBoxTheme.CreateDark()
+            ExOverlayMsgBoxTheme.Current = ExOverlayMsgBoxTheme.CreateDark()
+        End If
+    End Sub
+End Module

--- a/FFmpegFreeUI/功能/设置_v6.vb
+++ b/FFmpegFreeUI/功能/设置_v6.vb
@@ -25,6 +25,10 @@ Public Class 设置_v6
     Public Property 图形DX_HDR图片映射 As Integer = 0
 
     Public Property 窗口样式 As Integer = 2
+    ''' <summary>0=跟随 Windows 应用浅/深色模式；1=始终深色。</summary>
+    Public Property 界面主题 As Integer = 0
+    ''' <summary>0=直角；1=圆角。旧配置缺少此字段时，Windows 11 默认圆角，其他系统默认直角。</summary>
+    Public Property 窗口圆角 As Integer = If(LakeUI.DwmWindowStyle.IsCornerModeSupported, 1, 0)
     Public Property 启用性能计数器 As Integer = 0
 
     Public Property 字体 As String = SystemFonts.DefaultFont.FontFamily.Name
@@ -169,6 +173,7 @@ Public Class 设置_v6
 
         Form_v6_设置_LakeUI视觉体验.MCB_窗口样式.SelectedIndex = 实例对象.窗口样式
         Form_v6_设置_LakeUI视觉体验.MCB_性能计数器.SelectedIndex = 实例对象.启用性能计数器
+        Form_v6_设置_LakeUI视觉体验.加载新增外观设置()
 
         Form_v6_设置_性能调度.MTB_处理器线程.Text = 实例对象.指定处理器核心
         Form_v6_设置_性能调度.MCB_自动开始数量.SelectedIndex = 实例对象.自动同时运行任务数量选项

--- a/FFmpegFreeUI/界面 v6 主页面/FormMain_v6.vb
+++ b/FFmpegFreeUI/界面 v6 主页面/FormMain_v6.vb
@@ -15,6 +15,8 @@ Public Class FormMain_v6
         UI同步上下文 = Threading.SynchronizationContext.Current
         设置_v6.启动时读取SP解锁器()
         设置_v6.启动时加载设置()
+        界面主题_v6.初始化()
+        界面主题_v6.应用窗口圆角设置()
         网络功能.启动时后台获取SPAgent端点()
 
         设置_v6.加载SP自定义图标()

--- a/FFmpegFreeUI/界面 v6 设置/Form_v6_设置_LakeUI视觉体验.vb
+++ b/FFmpegFreeUI/界面 v6 设置/Form_v6_设置_LakeUI视觉体验.vb
@@ -1,4 +1,122 @@
 Public Class Form_v6_设置_LakeUI视觉体验
+    Private WithEvents MCB_界面主题 As LakeUI.ModernComboBox
+    Private WithEvents MCB_窗口圆角 As LakeUI.ModernComboBox
+
+    Private _窗口圆角说明 As LakeUI.HtmlColorLabel
+    Private _正在加载新增外观设置 As Boolean
+
+    Public Sub New()
+        InitializeComponent()
+        初始化新增外观控件()
+    End Sub
+
+    Private Sub 初始化新增外观控件()
+        MCB_界面主题 = 创建外观下拉框()
+        MCB_界面主题.Name = "MCB_界面主题"
+        MCB_界面主题.Items.Add("跟随 Windows")
+        MCB_界面主题.Items.Add("始终深色")
+        Dim 主题说明 = 创建说明标签("浅色模式：跟随 Windows 的应用模式设置；系统切换浅色/深色时界面即时同步")
+        Dim 主题行 = 创建设置行(MCB_界面主题, 主题说明)
+        主题行.Name = "Panel_界面主题"
+
+        MCB_窗口圆角 = 创建外观下拉框()
+        MCB_窗口圆角.Name = "MCB_窗口圆角"
+        MCB_窗口圆角.Items.Add("直角")
+        MCB_窗口圆角.Items.Add("圆角")
+        _窗口圆角说明 = 创建说明标签("Windows 11 默认圆角；旧版 Windows 不支持此 DWM 能力")
+        Dim 圆角行 = 创建设置行(MCB_窗口圆角, _窗口圆角说明)
+        圆角行.Name = "Panel_窗口圆角"
+
+        ModernPanel1.Controls.Add(主题行)
+        ModernPanel1.Controls.SetChildIndex(主题行, 0)
+        ModernPanel1.Controls.Add(圆角行)
+        ModernPanel1.Controls.SetChildIndex(圆角行, 0)
+    End Sub
+
+    Private Shared Function 创建外观下拉框() As LakeUI.ModernComboBox
+        Dim combo As New LakeUI.ModernComboBox With {
+            .BackColor1 = Color.FromArgb(CByte(40), CByte(220), CByte(220), CByte(220)),
+            .BorderRadius = 10,
+            .BorderSize = 0,
+            .Dock = DockStyle.Left,
+            .DropDownBackdropBlurPasses = 2,
+            .DropDownBackdropBlurRadius = 30,
+            .DropDownBackdropMode = LakeUI.PopupBackdropMode.Auto,
+            .DropDownHoverColor = Color.FromArgb(CByte(20), CByte(220), CByte(220), CByte(220)),
+            .DropDownMode = LakeUI.ModernComboBox.DropDownDisplayMode.Overlay,
+            .DropDownPadding = New Padding(10),
+            .DropDownSelectedColor = Color.FromArgb(CByte(40), CByte(220), CByte(220), CByte(220)),
+            .DropDownSelectedForeColor = Color.White,
+            .HoverBackColor1 = Color.FromArgb(CByte(60), CByte(220), CByte(220), CByte(220)),
+            .Margin = New Padding(2),
+            .Padding = New Padding(10, 0, 10, 0),
+            .SelectionColor = Color.FromArgb(CByte(40), CByte(220), CByte(220), CByte(220)),
+            .Size = New Size(200, 32),
+            .ToolTipGap = -1,
+            .ToolTipMaxWidth = 350,
+            .ToolTipPadding = New Padding(15),
+            .WaterTextForeColor = Color.FromArgb(CByte(120), CByte(255), CByte(255), CByte(255))
+        }
+        Return combo
+    End Function
+
+    Private Shared Function 创建说明标签(text As String) As LakeUI.HtmlColorLabel
+        Return New LakeUI.HtmlColorLabel With {
+            .AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            .Dock = DockStyle.Fill,
+            .ForeColor = Color.FromArgb(CByte(120), CByte(255), CByte(255), CByte(255)),
+            .Padding = New Padding(10, 0, 0, 0),
+            .Text = text,
+            .TextAlign = LakeUI.HtmlColorLabel.TextAlignEnum.MiddleLeft
+        }
+    End Function
+
+    Private Shared Function 创建设置行(combo As LakeUI.ModernComboBox, description As LakeUI.HtmlColorLabel) As LakeUI.ModernPanel
+        Dim panel As New LakeUI.ModernPanel With {
+            .BackColor = Color.Transparent,
+            .BackColor1 = Color.Transparent,
+            .BorderSize = 0,
+            .Dock = DockStyle.Top,
+            .Padding = New Padding(0, 10, 0, 0),
+            .Size = New Size(702, 42)
+        }
+        panel.Controls.Add(description)
+        panel.Controls.Add(combo)
+        Return panel
+    End Function
+
+    Friend Sub 加载新增外观设置()
+        _正在加载新增外观设置 = True
+        Try
+            MCB_界面主题.SelectedIndex = Math.Clamp(设置_v6.实例对象.界面主题, 0, 1)
+
+            If LakeUI.DwmWindowStyle.IsCornerModeSupported Then
+                MCB_窗口圆角.Enabled = True
+                MCB_窗口圆角.SelectedIndex = Math.Clamp(设置_v6.实例对象.窗口圆角, 0, 1)
+                _窗口圆角说明.Text = "Windows 11 默认圆角；可在此切回直角，修改后即时生效"
+            Else
+                设置_v6.实例对象.窗口圆角 = 0
+                MCB_窗口圆角.SelectedIndex = 0
+                MCB_窗口圆角.Enabled = False
+                _窗口圆角说明.Text = "当前系统不支持窗口圆角，需要 Windows 11 Build 22000 或更高版本"
+            End If
+        Finally
+            _正在加载新增外观设置 = False
+        End Try
+    End Sub
+
+    Private Sub MCB_界面主题_SelectedIndexChanged(sender As Object, e As EventArgs) Handles MCB_界面主题.SelectedIndexChanged
+        If _正在加载新增外观设置 OrElse MCB_界面主题.SelectedIndex < 0 Then Return
+        设置_v6.实例对象.界面主题 = MCB_界面主题.SelectedIndex
+        界面主题_v6.刷新主题(True)
+    End Sub
+
+    Private Sub MCB_窗口圆角_SelectedIndexChanged(sender As Object, e As EventArgs) Handles MCB_窗口圆角.SelectedIndexChanged
+        If _正在加载新增外观设置 OrElse MCB_窗口圆角.SelectedIndex < 0 Then Return
+        设置_v6.实例对象.窗口圆角 = If(LakeUI.DwmWindowStyle.IsCornerModeSupported, MCB_窗口圆角.SelectedIndex, 0)
+        界面主题_v6.应用窗口圆角设置()
+    End Sub
+
     Private Sub MCB_窗口样式_SelectedIndexChanged(sender As Object, e As EventArgs) Handles MCB_窗口样式.SelectedIndexChanged
         设置_v6.实例对象.窗口样式 = MCB_窗口样式.SelectedIndex
     End Sub


### PR DESCRIPTION
## 变更

### 跟随 Windows 应用主题

- 新增界面主题设置，默认“跟随 Windows”。
- 读取 `HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize\AppsUseLightTheme`，明确跟随应用浅/深色，而不是任务栏/系统模式。
- 监听 `SystemEvents.UserPreferenceChanged`，系统切换应用主题后即时刷新已经打开的界面；后续动态加入的控件也继承当前主题。
- 主题转换基于原始深色设计值保存快照，浅色 → 深色可精确恢复，不做累计反色。
- 仅映射中性灰阶颜色，保留警告色、状态色、图表色等语义强调色。
- 同步覆盖 `HtmlColorLabel` 的 HTML 颜色、LakeUI 五类对话框主题，以及非 Control 的 `ThisIsYourWindow` 自定义标题栏颜色。

### 窗口圆角

- 新增“直角 / 圆角”设置，并依赖 LakeUI PR：Lake1059/LakeUI#1。
- Windows 11 Build 22000+ 的旧配置默认圆角；不支持该 DWM 能力的旧版 Windows 默认直角，并禁用该选项同时显示系统要求。
- `LakeUI 特别呈现` 模式通过 `ThisIsYourWindow.WindowCornerMode` 即时更新；全屏仍保持直角。

## 关于 6.2.2 更新卡死

原问题已经由当前基线 FFmpegFreeUI 6.2.3 / LakeUI 5.3 的上游提交修复，本 PR 基于这两个版本开发，因此没有重复修改更新器逻辑。

## 验证

- `dotnet build FFmpegFreeUI/FFmpegFreeUI.vbproj -c Debug --no-restore` → 0 warnings / 0 errors
- `git diff --check` → pass
- 运行时冒烟验证：
  - 浅色窗体背景/前景：`#F9F9F9 / #3F3F3F`
  - 深色恢复：`#181818 / Silver`
  - `ThisIsYourWindow` 标题栏浅色：`#F3F3F3 / #3F3F3F`，切回深色后恢复原值
  - Windows 应用主题读取与 `AppsUseLightTheme` 当前值一致
  - Windows 11 默认圆角，设置页圆角控件可用；新增两项布局和选项数量已检查