### PR TITLE
fix(ui): improve light theme contrast

### DIFF
--- a/FFmpegFreeUI/功能/其他初始化.vb
+++ b/FFmpegFreeUI/功能/其他初始化.vb
@@ -10,7 +10,7 @@ Public Class 其他初始化
         LakeUI.MessageDialogOptions.BackdropTintColor = Color.FromArgb(120, 0, 0, 0)
         LakeUI.MessageDialogOptions.BackdropBlurRadius = 30
         LakeUI.MessageDialogOptions.BackdropBlurPasses = 2
-        LakeUI.FloatingToolTipForm.BackdropEnabled = True
+        LakeUI.FloatingToolTipForm.BackdropEnabled = Not 界面主题_v6.当前为浅色模式
         LakeUI.FloatingToolTipForm.BackdropTintColor = Color.FromArgb(120, 0, 0, 0)
         LakeUI.FloatingToolTipForm.BackdropBlurRadius = 30
         LakeUI.FloatingToolTipForm.BackdropBlurPasses = 2

--- a/FFmpegFreeUI/功能/界面主题_v6.vb
+++ b/FFmpegFreeUI/功能/界面主题_v6.vb
@@ -25,6 +25,7 @@ Public Module 界面主题_v6
     Private ReadOnly 浅色多级导航背景 As Color = Color.FromArgb(230, 230, 230)
     Private ReadOnly 浅色基础背景 As Color = Color.FromArgb(239, 239, 239)
     Private ReadOnly 浅色表面背景 As Color = Color.White
+    Private ReadOnly 浅色强调绿色 As Color = Color.FromArgb(0, 122, 0)
 
     <DllImport("dwmapi.dll")>
     Private Function DwmGetColorizationColor(ByRef colorization As UInteger,
@@ -46,6 +47,10 @@ Public Module 界面主题_v6
             Return _当前浅色
         End Get
     End Property
+
+    Public Function 获取当前主题前景色(original As Color) As Color
+        Return If(_当前浅色, 转换为浅色(original, "ForeColor"), original)
+    End Function
 
     ''' <summary>初始化系统主题监听，并立即将当前 Windows“应用模式”应用到已加载界面。</summary>
     Public Sub 初始化()
@@ -230,7 +235,11 @@ Public Module 界面主题_v6
 
         If 首次挂接 OrElse 强制刷新 Then
             应用对象颜色(control, _当前浅色)
-            If TypeOf control Is Form Then 应用窗体Dwm外观(DirectCast(control, Form))
+            If TypeOf control Is Form Then
+                Dim form = DirectCast(control, Form)
+                应用窗体组件颜色(form, _当前浅色)
+                应用窗体Dwm外观(form)
+            End If
             control.Invalidate()
         End If
 
@@ -242,6 +251,14 @@ Public Module 界面主题_v6
     Private Sub 控件已添加(sender As Object, e As ControlEventArgs)
         If Not _已初始化 OrElse e.Control Is Nothing Then Return
         应用控件树(e.Control, True)
+    End Sub
+
+    Private Sub 应用窗体组件颜色(form As Form, 浅色 As Boolean)
+        For Each field In form.GetType().GetFields(BindingFlags.Instance Or BindingFlags.Public Or BindingFlags.NonPublic)
+            If Not GetType(ModernContextMenu).IsAssignableFrom(field.FieldType) Then Continue For
+            Dim menu = TryCast(field.GetValue(form), ModernContextMenu)
+            If menu IsNot Nothing Then 应用对象颜色(menu, 浅色)
+        Next
     End Sub
 
     Private Sub 应用窗体Dwm外观(form As Form)
@@ -352,6 +369,7 @@ Public Module 界面主题_v6
         Dim isForeground = name.Contains("ForeColor", StringComparison.OrdinalIgnoreCase) OrElse
                            name.Contains("TextColor", StringComparison.OrdinalIgnoreCase)
         If isForeground Then
+            If original.ToArgb() = Color.YellowGreen.ToArgb() Then Return 浅色强调绿色
             Dim alpha = If(original.A < 255, Math.Max(CInt(original.A), 210), 255)
             Dim candidate As Color
             If neutral Then
@@ -472,6 +490,7 @@ Public Module 界面主题_v6
     End Function
 
     Private Sub 应用LakeUI对话框主题(浅色 As Boolean)
+        FloatingToolTipForm.BackdropEnabled = Not 浅色
         If 浅色 Then
             ExMsgBoxTheme.Current = ExMsgBoxTheme.CreateLight()
             ExInputBoxTheme.Current = ExInputBoxTheme.CreateLight()

--- a/FFmpegFreeUI/功能/编码队列展示策略_v6.vb
+++ b/FFmpegFreeUI/功能/编码队列展示策略_v6.vb
@@ -139,7 +139,9 @@ Public Class 旧版兼容编码队列展示策略_v6
 
         Dim text = task.最新底部日志文本.Replace(vbCr, " ").Replace(vbLf, " ").Trim()
         If text = "" Then Exit Sub
-        Dim color As Color = If(task.最新底部日志是否错误, 界面配色_v6.错误文本色, Color.FromArgb(150, 220, 220, 220))
+        Dim color As Color = If(task.最新底部日志是否错误,
+                                界面配色_v6.错误文本色,
+                                If(界面主题_v6.当前为浅色模式, Color.Black, Color.FromArgb(150, 220, 220, 220)))
         item.BottomLines.Add(New UltraDetailListView.TextLine(text, Nothing, color))
     End Sub
 

--- a/FFmpegFreeUI/集成工具/Form_v6_集成工具_质量评测.vb
+++ b/FFmpegFreeUI/集成工具/Form_v6_集成工具_质量评测.vb
@@ -1533,7 +1533,7 @@ Public Class Form_v6_集成工具_质量评测
 
     Private Sub 设置运行状态(running As Boolean)
         MB_开始评测.Text = If(running, "取消评测", "开始评测")
-        MB_开始评测.ForeColor = If(running, Color.IndianRed, Color.YellowGreen)
+        MB_开始评测.ForeColor = If(running, Color.IndianRed, 界面主题_v6.获取当前主题前景色(Color.YellowGreen))
         MB_选择原视频.Enabled = Not running
         MB_移除选中文件.Enabled = Not running
         MB_移除全部文件.Enabled = Not running
@@ -1634,7 +1634,7 @@ Public Class Form_v6_集成工具_质量评测
         Next
 
         If scoredItems.Count = 1 Then
-            scoredItems(0).Item.SubItems(index).ForeColor = Color.YellowGreen
+            scoredItems(0).Item.SubItems(index).ForeColor = 界面主题_v6.获取当前主题前景色(Color.YellowGreen)
         ElseIf scoredItems.Count > 1 Then
             Dim minValue = scoredItems.Min(Function(x) x.Value)
             Dim maxValue = scoredItems.Max(Function(x) x.Value)
@@ -1642,7 +1642,7 @@ Public Class Form_v6_集成工具_质量评测
             For Each entry In scoredItems
                 Dim color As Color
                 If entry.Value.Equals(maxValue) Then
-                    color = Color.YellowGreen
+                    color = 界面主题_v6.获取当前主题前景色(Color.YellowGreen)
                 ElseIf entry.Value.Equals(minValue) Then
                     color = Color.IndianRed
                 Else
@@ -1656,12 +1656,13 @@ Public Class Form_v6_集成工具_质量评测
     End Sub
 
     Private Shared Function 获取评分渐变颜色(value As Double, minValue As Double, maxValue As Double) As Color
-        If Double.IsInfinity(value) Then Return Color.YellowGreen
+        If Double.IsInfinity(value) Then Return 界面主题_v6.获取当前主题前景色(Color.YellowGreen)
         If Double.IsInfinity(minValue) OrElse Double.IsInfinity(maxValue) OrElse maxValue <= minValue Then Return Color.Silver
         Dim ratio = Math.Max(0.0, Math.Min(1.0, (value - minValue) / (maxValue - minValue)))
-        Dim r = CInt(205 + (154 - 205) * ratio)
-        Dim g = CInt(92 + (205 - 92) * ratio)
-        Dim b = CInt(92 + (50 - 92) * ratio)
+        Dim best = 界面主题_v6.获取当前主题前景色(Color.YellowGreen)
+        Dim r = CInt(205 + (best.R - 205) * ratio)
+        Dim g = CInt(92 + (best.G - 92) * ratio)
+        Dim b = CInt(92 + (best.B - 92) * ratio)
         Return Color.FromArgb(r, g, b)
     End Function
 


### PR DESCRIPTION
## 变更
- 在主题层统一处理设计器创建的 `ModernContextMenu`，修复浅色模式菜单底色和文字颜色
- 浅色模式关闭 `FloatingToolTipForm` 深色背景，并避免初始化阶段覆盖
- 编码队列底部普通日志改为黑字；质量评测绿色改为高饱和、可读的主题色
- 不修改 LakeUI 源码

## 验证
- `dotnet build FFmpegFreeUI.sln -c Release --no-restore`：0 警告，0 错误
- 主题切换、菜单颜色和提示框初始化反射冒烟通过
- GUI 视觉效果待人工审计