### PR TITLE
fix(ui): refine light theme contrast

### DIFF
--- a/FFmpegFreeUI/功能/FFmpeg输出语法高亮器_v6.vb
+++ b/FFmpegFreeUI/功能/FFmpeg输出语法高亮器_v6.vb
@@ -38,12 +38,12 @@ Public Class FFmpeg输出语法高亮器_v6
         If text.Length = 0 Then Return New ModernTextBox.SyntaxHighlightResult(tokens, 0)
 
         If 编码队列_v6.是否错误输出(text) Then
-            tokens.Add(New ModernTextBox.SyntaxToken(0, text.Length, 颜色_错误))
+            添加片段(tokens, 0, text.Length, 颜色_错误)
             Return New ModernTextBox.SyntaxHighlightResult(tokens, 0)
         End If
 
         If text.Contains("warning", StringComparison.OrdinalIgnoreCase) OrElse text.Contains("deprecated", StringComparison.OrdinalIgnoreCase) Then
-            tokens.Add(New ModernTextBox.SyntaxToken(0, text.Length, 颜色_警告))
+            添加片段(tokens, 0, text.Length, 颜色_警告)
             Return New ModernTextBox.SyntaxHighlightResult(tokens, 0)
         End If
 
@@ -109,6 +109,26 @@ Public Class FFmpeg输出语法高亮器_v6
             Dim tokenEnd = token.StartCol + token.Length
             If token.StartCol < endCol AndAlso startCol < tokenEnd Then Exit Sub
         Next
-        tokens.Add(New ModernTextBox.SyntaxToken(startCol, length, color))
+        tokens.Add(New ModernTextBox.SyntaxToken(startCol, length, 获取当前显示颜色(color)))
     End Sub
+
+    Private Shared Function 获取当前显示颜色(color As Color) As Color
+        If Not 界面主题_v6.当前为浅色模式 Then Return color
+
+        Select Case color.ToArgb()
+            Case 颜色_错误.ToArgb() : Return Color.FromArgb(163, 38, 30)
+            Case 颜色_警告.ToArgb() : Return Color.FromArgb(130, 80, 0)
+            Case 颜色_系统.ToArgb() : Return Color.FromArgb(0, 85, 164)
+            Case 颜色_输入.ToArgb() : Return Color.FromArgb(0, 97, 55)
+            Case 颜色_输出.ToArgb() : Return Color.FromArgb(152, 69, 0)
+            Case 颜色_流编号.ToArgb() : Return Color.FromArgb(113, 54, 143)
+            Case 颜色_流类型.ToArgb() : Return Color.FromArgb(156, 60, 0)
+            Case 颜色_键名.ToArgb() : Return Color.FromArgb(0, 96, 104)
+            Case 颜色_数值.ToArgb() : Return Color.FromArgb(0, 90, 168)
+            Case 颜色_格式.ToArgb() : Return Color.FromArgb(74, 97, 0)
+            Case 颜色_路径.ToArgb() : Return Color.FromArgb(75, 85, 93)
+            Case 颜色_选项.ToArgb() : Return Color.FromArgb(96, 64, 153)
+            Case Else : Return 界面主题_v6.获取当前主题前景色(color)
+        End Select
+    End Function
 End Class

--- a/FFmpegFreeUI/功能/Module1.vb
+++ b/FFmpegFreeUI/功能/Module1.vb
@@ -387,6 +387,7 @@ Module Module1
     End Function
 
     Public Sub 显示窗体(哪个窗口 As Form, 以谁为基准显示 As Form)
+        界面主题_v6.应用当前主题到窗体(哪个窗口)
         If 哪个窗口.Visible = True Then
             哪个窗口.Focus()
             哪个窗口.Left = (以谁为基准显示.Width - 哪个窗口.Width) * 0.5 + 以谁为基准显示.Left
@@ -395,6 +396,7 @@ Module Module1
             哪个窗口.Left = (以谁为基准显示.Width - 哪个窗口.Width) * 0.5 + 以谁为基准显示.Left
             哪个窗口.Top = (以谁为基准显示.Height - 哪个窗口.Height) * 0.5 + 以谁为基准显示.Top
             哪个窗口.Show(以谁为基准显示)
+            界面主题_v6.应用当前主题到窗体(哪个窗口)
         End If
     End Sub
 

--- a/FFmpegFreeUI/功能/界面主题_v6.vb
+++ b/FFmpegFreeUI/功能/界面主题_v6.vb
@@ -26,6 +26,7 @@ Public Module 界面主题_v6
     Private ReadOnly 浅色基础背景 As Color = Color.FromArgb(239, 239, 239)
     Private ReadOnly 浅色表面背景 As Color = Color.White
     Private ReadOnly 浅色强调绿色 As Color = Color.FromArgb(0, 122, 0)
+    Private ReadOnly 浅色强调橙色 As Color = Color.FromArgb(145, 58, 0)
 
     <DllImport("dwmapi.dll")>
     Private Function DwmGetColorizationColor(ByRef colorization As UInteger,
@@ -48,9 +49,15 @@ Public Module 界面主题_v6
         End Get
     End Property
 
-    Public Function 获取当前主题前景色(original As Color) As Color
-        Return If(_当前浅色, 转换为浅色(original, "ForeColor"), original)
+    Public Function 获取当前主题前景色(original As Color, Optional 最低对比度 As Double = 4.5R) As Color
+        Return If(_当前浅色, 转换为浅色(original, "ForeColor", Nothing, 最低对比度), original)
     End Function
+
+    Public Sub 应用当前主题到窗体(form As Form)
+        If form Is Nothing OrElse form.IsDisposed Then Return
+        If Not _已初始化 Then 刷新主题(True)
+        应用控件树(form, True)
+    End Sub
 
     ''' <summary>初始化系统主题监听，并立即将当前 Windows“应用模式”应用到已加载界面。</summary>
     Public Sub 初始化()
@@ -66,7 +73,7 @@ Public Module 界面主题_v6
         刷新主题(True)
     End Sub
 
-    ''' <summary>0=跟随 Windows 应用模式；1=始终使用明亮；2=始终使用暗黑。</summary>
+    ''' <summary>0=跟随 Windows 应用模式；1=始终使用浅色模式；2=始终使用深色模式。</summary>
     Public Sub 刷新主题(Optional 强制刷新 As Boolean = False)
         Dim 浅色 As Boolean
         Select Case 设置_v6.实例对象.界面主题
@@ -296,6 +303,11 @@ Public Module 界面主题_v6
             Catch
             End Try
         End If
+
+        If TypeOf target Is ModernTextBox Then
+            Dim textBox = DirectCast(target, ModernTextBox)
+            If textBox.EnableSyntaxHighlight AndAlso textBox.SyntaxHighlighter IsNot Nothing Then textBox.SyntaxHighlighter = textBox.SyntaxHighlighter
+        End If
     End Sub
 
     Private Function 获取或创建快照(target As Object) As 控件主题快照
@@ -335,7 +347,7 @@ Public Module 界面主题_v6
             End Function)
     End Function
 
-    Private Function 转换为浅色(original As Color, propertyName As String, Optional target As Object = Nothing) As Color
+    Private Function 转换为浅色(original As Color, propertyName As String, Optional target As Object = Nothing, Optional 最低对比度 As Double = 4.5R) As Color
         If original.IsEmpty OrElse original.A = 0 Then Return original
 
         Dim name = If(propertyName, String.Empty)
@@ -370,6 +382,7 @@ Public Module 界面主题_v6
                            name.Contains("TextColor", StringComparison.OrdinalIgnoreCase)
         If isForeground Then
             If original.ToArgb() = Color.YellowGreen.ToArgb() Then Return 浅色强调绿色
+            If original.ToArgb() = Color.Orange.ToArgb() Then Return 浅色强调橙色
             Dim alpha = If(original.A < 255, Math.Max(CInt(original.A), 210), 255)
             Dim candidate As Color
             If neutral Then
@@ -385,7 +398,7 @@ Public Module 界面主题_v6
             Else
                 candidate = Color.FromArgb(alpha, original.R, original.G, original.B)
             End If
-            Return 确保浅色前景对比度(candidate, 4.5R)
+            Return 确保浅色前景对比度(candidate, 最低对比度)
         End If
 
         Dim isBorder = name.Contains("Border", StringComparison.OrdinalIgnoreCase) OrElse

--- a/FFmpegFreeUI/功能/设置_v6.vb
+++ b/FFmpegFreeUI/功能/设置_v6.vb
@@ -25,7 +25,7 @@ Public Class 设置_v6
     Public Property 图形DX_HDR图片映射 As Integer = 0
 
     Public Property 窗口样式 As Integer = 2
-    ''' <summary>0=跟随 Windows 应用浅/深色模式；1=始终明亮；2=始终暗黑。</summary>
+    ''' <summary>0=跟随 Windows 应用浅/深色模式；1=始终浅色模式；2=始终深色模式。</summary>
     Public Property 界面主题 As Integer = 2
     ''' <summary>0=直角；1=圆角。旧配置缺少此字段时，Windows 11 默认圆角，其他系统默认直角。</summary>
     Public Property 窗口圆角 As Integer = If(LakeUI.DwmWindowStyle.IsCornerModeSupported, 1, 0)

--- a/FFmpegFreeUI/界面 v6 主页面/Form_v6_编码队列.vb
+++ b/FFmpegFreeUI/界面 v6 主页面/Form_v6_编码队列.vb
@@ -127,10 +127,11 @@ Public Class Form_v6_编码队列
         Dim items = 编码队列_v6.获取队列快照()
         Dim running = items.Where(Function(x) x.状态 = 编码任务状态_v6.正在处理 OrElse x.状态 = 编码任务状态_v6.已暂停).Count()
         Dim errors = items.Where(Function(x) x.状态 = 编码任务状态_v6.错误).Count()
+        Dim 标签颜色 = System.Drawing.ColorTranslator.ToHtml(界面主题_v6.获取当前主题前景色(Color.DarkGray))
         HtmlColorLabel1.Text =
-            $"<span style=""color:DarkGray"">总数 </span><span style=""font-size:14pt; font-weight:bold; color:CornflowerBlue"">{items.Count}</span>" &
-            $"   <span style=""color:DarkGray"">运行 </span><span style=""font-size:14pt; font-weight:bold; color:YellowGreen"">{running}</span>" &
-            $"   <span style=""color:DarkGray"">错误 </span><span style=""font-size:14pt; font-weight:bold; color:{界面配色_v6.错误文本色Html}"">{errors}</span>"
+            $"<span style=""color:{标签颜色}"">总数 </span><span style=""font-size:14pt; font-weight:bold; color:CornflowerBlue"">{items.Count}</span>" &
+            $"   <span style=""color:{标签颜色}"">运行 </span><span style=""font-size:14pt; font-weight:bold; color:YellowGreen"">{running}</span>" &
+            $"   <span style=""color:{标签颜色}"">错误 </span><span style=""font-size:14pt; font-weight:bold; color:{界面配色_v6.错误文本色Html}"">{errors}</span>"
     End Sub
 
     Private Sub Panel1_SizeChanged(sender As Object, e As EventArgs) Handles Panel1.SizeChanged

--- a/FFmpegFreeUI/界面 v6 参数面板/Form_v6_参数面板_滤镜排序.vb
+++ b/FFmpegFreeUI/界面 v6 参数面板/Form_v6_参数面板_滤镜排序.vb
@@ -159,7 +159,7 @@ Public Class Form_v6_参数面板_滤镜排序
             For Each item In _items
                 Dim lv As New UltraDetailListView.ListItem()
                 Dim 标识符项 As New UltraDetailListView.ListSubItem With {.Text = If(item.显示名称 <> "", item.显示名称, item.滤镜标识符.ToString())}
-                If 可直接编辑滤镜内容(item) Then 标识符项.ForeColor = Color.Orange
+                If 可直接编辑滤镜内容(item) Then 标识符项.ForeColor = 界面主题_v6.获取当前主题前景色(Color.Orange)
                 lv.SubItems.Add(标识符项)
                 lv.SubItems.Add(New UltraDetailListView.ListSubItem With {.Text = item.滤镜目标流类型.ToString()})
                 lv.SubItems.Add(New UltraDetailListView.ListSubItem With {.Text = item.自定义滤镜内容})

--- a/FFmpegFreeUI/界面 v6 设置/Form_v6_设置_界面显示.Designer.vb
+++ b/FFmpegFreeUI/界面 v6 设置/Form_v6_设置_界面显示.Designer.vb
@@ -142,8 +142,8 @@ Partial Class Form_v6_设置_界面显示
         MCB_界面主题.DropDownSelectedForeColor = Color.White
         MCB_界面主题.HoverBackColor1 = Color.FromArgb(CByte(60), CByte(220), CByte(220), CByte(220))
         MCB_界面主题.Items.Add("跟随 Windows")
-        MCB_界面主题.Items.Add("明亮")
-        MCB_界面主题.Items.Add("暗黑")
+        MCB_界面主题.Items.Add("浅色模式")
+        MCB_界面主题.Items.Add("深色模式")
         MCB_界面主题.Location = New Point(0, 10)
         MCB_界面主题.Margin = New Padding(2, 2, 2, 2)
         MCB_界面主题.Name = "MCB_界面主题"
@@ -168,7 +168,7 @@ Partial Class Form_v6_设置_界面显示
         HtmlColorLabel2.Padding = New Padding(0, 20, 0, 0)
         HtmlColorLabel2.Size = New Size(712, 43)
         HtmlColorLabel2.TabIndex = 12
-        HtmlColorLabel2.Text = "<span style=""font-size:13; color:Silver"">界面主题</span>   选择应用使用的明亮或暗黑配色，也可跟随 Windows 设置"
+        HtmlColorLabel2.Text = "<span style=""font-size:13; color:Silver"">界面主题</span>   选择应用使用的浅色模式或深色模式配色，也可跟随 Windows 设置"
         ' 
         ' Panel2
         ' 


### PR DESCRIPTION
## Summary
- Apply the selected theme before secondary windows are shown.
- Preserve saturated, high-contrast syntax and editable-filter colors in light mode.
- Render the queue labels in dark gray in light mode and rename the theme choices to light/dark mode.

## Validation
- `dotnet build FFmpegFreeUI.sln --configuration Debug`
- Isolated Release build of `FFmpegFreeUI.vbproj` with 0 warnings and 0 errors.